### PR TITLE
Fixed materials not converting correctly if they have underscores in their name

### DIFF
--- a/SuperBMDLib/source/BMD/MAT3.cs
+++ b/SuperBMDLib/source/BMD/MAT3.cs
@@ -508,20 +508,20 @@ namespace SuperBMDLib.BMD
                 Assimp.Material meshMat = scene.Materials[scene.Meshes[i].MaterialIndex];
                 string test = meshMat.Name.Replace("-material", "");
 
-                if (test.Contains("_"))
+                List<string> materialNamesWithoutParentheses = new List<string>();
+                foreach (string materialName in m_MaterialNames)
                 {
-                    string[] without_underscores = test.Split('_');
-                    test = $"{ without_underscores[0] }({ without_underscores[1] })";
+                    materialNamesWithoutParentheses.Add(materialName.Replace("(", "_").Replace(")", "_"));
                 }
 
-                while (!m_MaterialNames.Contains(test))
+                while (!materialNamesWithoutParentheses.Contains(test))
                 {
                     test = test.Substring(1);
                 }
 
                 for (int j = 0; j < m_Materials.Count; j++)
                 {
-                    if (test == m_MaterialNames[j])
+                    if (test == materialNamesWithoutParentheses[j])
                     {
                         scene.Meshes[i].MaterialIndex = j;
                         break;


### PR DESCRIPTION
When materials are converted from BDL -> DAE, AssimpNet automatically converts parentheses in their names to underscores.
So then when loading the materials back from materials.json for converting DAE -> BMD, there's code that converts underscores back to parentheses.

But that code causes issues for material names that *originally* had underscores in their name (like a material in the Hero's Charm model), since the underscores are converted to parentheses and then detection of which material is which doesn't work.
So I changed how it compares material names so that it works correctly for materials that have underscores in them and also for ones that have parentheses in them.