### PR TITLE
Fix encoding image formats C8 and C4 not working correctly

### DIFF
--- a/SuperBMDLib/source/BMD/TEX1.cs
+++ b/SuperBMDLib/source/BMD/TEX1.cs
@@ -160,6 +160,7 @@ namespace SuperBMDLib.BMD
                 if (image_palette_Data.ContainsKey(img.Name))
                 {
                     img.PaletteCount = (ushort)image_palette_Data[img.Name].Item2.Length;
+                    img.PalettesEnabled = (image_palette_Data[img.Name].Item2.Length > 0);
                 }
                 else
                 {

--- a/SuperBMDLib/source/BMD/TEX1.cs
+++ b/SuperBMDLib/source/BMD/TEX1.cs
@@ -157,15 +157,19 @@ namespace SuperBMDLib.BMD
 
             foreach (BinaryTextureImage img in Textures)
             {
-                names.Add(img.Name);
-                img.WriteHeader(writer);
-
-                if (!image_palette_Data.ContainsKey(img.Name))
+                if (image_palette_Data.ContainsKey(img.Name))
+                {
+                    img.PaletteCount = (ushort)image_palette_Data[img.Name].Item2.Length;
+                }
+                else
                 {
                     image_palette_Data.Add(img.Name, img.EncodeData());
                     imageDataOffsets.Add(img.Name, 0);
                     paletteDataOffsets.Add(img.Name, 0);
                 }
+
+                names.Add(img.Name);
+                img.WriteHeader(writer);
             }
 
             long curOffset = writer.BaseStream.Position;

--- a/SuperBMDLib/source/Materials/BinaryTextureImage.cs
+++ b/SuperBMDLib/source/Materials/BinaryTextureImage.cs
@@ -129,7 +129,7 @@ namespace SuperBMDLib.Materials
         public WrapModes WrapS { get; set; }
         public WrapModes WrapT { get; set; }
 
-        public PaletteFormats PaletteFormat { get; private set; }
+        public PaletteFormats PaletteFormat { get; set; }
 
         public ushort PaletteCount { get; private set; }
 

--- a/SuperBMDLib/source/Materials/BinaryTextureImage.cs
+++ b/SuperBMDLib/source/Materials/BinaryTextureImage.cs
@@ -1041,6 +1041,9 @@ namespace SuperBMDLib.Materials
                 }
             }
 
+            PaletteCount = (ushort)rawColorData.Count;
+            PalettesEnabled = true;
+
             return new Tuple<byte[], ushort[]>(pixIndices, rawColorData.Keys.ToArray());
         }
 

--- a/SuperBMDLib/source/Materials/BinaryTextureImage.cs
+++ b/SuperBMDLib/source/Materials/BinaryTextureImage.cs
@@ -129,6 +129,8 @@ namespace SuperBMDLib.Materials
         public WrapModes WrapS { get; set; }
         public WrapModes WrapT { get; set; }
 
+        public bool PalettesEnabled { get; set; }
+
         public PaletteFormats PaletteFormat { get; set; }
 
         public ushort PaletteCount { get; set; }
@@ -180,7 +182,7 @@ namespace SuperBMDLib.Materials
             Height = stream.ReadUInt16();
             WrapS = (WrapModes)stream.ReadByte();
             WrapT = (WrapModes)stream.ReadByte();
-            byte unknown1 = stream.ReadByte();
+            PalettesEnabled = Convert.ToBoolean(stream.ReadByte());
             PaletteFormat = (PaletteFormats)stream.ReadByte();
             PaletteCount = stream.ReadUInt16();
             int paletteDataOffset = stream.ReadInt32();
@@ -327,8 +329,7 @@ namespace SuperBMDLib.Materials
             writer.Write((byte)WrapS);
             writer.Write((byte)WrapT);
 
-            // This is an unknown
-            writer.Write((byte)0);
+            writer.Write(Convert.ToByte(PalettesEnabled));
 
             writer.Write((byte)PaletteFormat);
             writer.Write((short)PaletteCount);
@@ -1077,6 +1078,7 @@ namespace SuperBMDLib.Materials
             }
 
             PaletteCount = (ushort)rawColorData.Count;
+            PalettesEnabled = true;
 
             return new Tuple<byte[], ushort[]>(pixIndices, rawColorData.Keys.ToArray());
         }

--- a/SuperBMDLib/source/Materials/BinaryTextureImage.cs
+++ b/SuperBMDLib/source/Materials/BinaryTextureImage.cs
@@ -131,7 +131,7 @@ namespace SuperBMDLib.Materials
 
         public PaletteFormats PaletteFormat { get; set; }
 
-        public ushort PaletteCount { get; private set; }
+        public ushort PaletteCount { get; set; }
 
         [JsonIgnore]
         public int EmbeddedPaletteOffset { get; private set; } // This is a guess. It seems to be 0 in most things, but it fits with min/mag filters.

--- a/SuperBMDLib/source/Materials/BinaryTextureImage.cs
+++ b/SuperBMDLib/source/Materials/BinaryTextureImage.cs
@@ -129,6 +129,7 @@ namespace SuperBMDLib.Materials
         public WrapModes WrapS { get; set; }
         public WrapModes WrapT { get; set; }
 
+        [JsonIgnore]
         public bool PalettesEnabled { get; set; }
 
         public PaletteFormats PaletteFormat { get; set; }
@@ -1018,11 +1019,12 @@ namespace SuperBMDLib.Materials
 
             for (int i = 0; i < (Width * Height) * 4; i += 4)
                 palColors.Add(new Util.Color32(m_rgbaImageData[i + 2], m_rgbaImageData[i + 1], m_rgbaImageData[i + 0], m_rgbaImageData[i + 3]));
-
-            SortedList<ushort, Util.Color32> rawColorData = new SortedList<ushort, Util.Color32>();
+            
+            List<ushort> rawColorData = new List<ushort>();
+            Dictionary<Util.Color32, byte> pixelColorIndexes = new Dictionary<Util.Color32, byte>();
             foreach (Util.Color32 col in palColors)
             {
-                EncodeColor(col, rawColorData);
+                EncodeColor(col, rawColorData, pixelColorIndexes);
             }
 
             int pixIndex = 0;
@@ -1034,8 +1036,10 @@ namespace SuperBMDLib.Materials
                     {
                         for (int pX = 0; pX < 8; pX += 2)
                         {
-                            pixIndices[pixIndex] = (byte)(rawColorData.IndexOfValue(palColors[Width * ((yBlock * 8) + pY) + (xBlock * 8) + pX]) << 4);
-                            pixIndices[pixIndex++] |= (byte)(rawColorData.IndexOfValue(palColors[Width * ((yBlock * 8) + pY) + (xBlock * 8) + pX + 1]));
+                            byte color1 = (byte)(pixelColorIndexes[palColors[Width * ((yBlock * 8) + pY) + (xBlock * 8) + pX]] & 0xF);
+                            byte color2 = (byte)(pixelColorIndexes[palColors[Width * ((yBlock * 8) + pY) + (xBlock * 8) + pX + 1]] & 0xF);
+                            pixIndices[pixIndex] = (byte)(color1 << 4);
+                            pixIndices[pixIndex++] |= color2;
                         }
                     }
                 }
@@ -1044,7 +1048,7 @@ namespace SuperBMDLib.Materials
             PaletteCount = (ushort)rawColorData.Count;
             PalettesEnabled = true;
 
-            return new Tuple<byte[], ushort[]>(pixIndices, rawColorData.Keys.ToArray());
+            return new Tuple<byte[], ushort[]>(pixIndices, rawColorData.ToArray());
         }
 
         private Tuple<byte[], ushort[]> EncodeC8()
@@ -1059,10 +1063,11 @@ namespace SuperBMDLib.Materials
             for (int i = 0; i < (Width * Height) * 4; i += 4)
                 palColors.Add(new Util.Color32(m_rgbaImageData[i + 2], m_rgbaImageData[i + 1], m_rgbaImageData[i + 0], m_rgbaImageData[i + 3]));
 
-            SortedList<ushort, Util.Color32> rawColorData = new SortedList<ushort, Util.Color32>();
+            List<ushort> rawColorData = new List<ushort>();
+            Dictionary<Util.Color32, byte> pixelColorIndexes = new Dictionary<Util.Color32, byte>();
             foreach (Util.Color32 col in palColors)
             {
-                EncodeColor(col, rawColorData);
+                EncodeColor(col, rawColorData, pixelColorIndexes);
             }
 
             int pixIndex = 0;
@@ -1074,7 +1079,7 @@ namespace SuperBMDLib.Materials
                     {
                         for (int pX = 0; pX < 8; pX++)
                         {
-                            pixIndices[pixIndex++] = (byte)rawColorData.IndexOfValue(palColors[Width * ((yBlock * 4) + pY) + (xBlock * 8) + pX]);
+                            pixIndices[pixIndex++] = pixelColorIndexes[palColors[Width * ((yBlock * 4) + pY) + (xBlock * 8) + pX]];
                         }
                     }
                 }
@@ -1083,10 +1088,10 @@ namespace SuperBMDLib.Materials
             PaletteCount = (ushort)rawColorData.Count;
             PalettesEnabled = true;
 
-            return new Tuple<byte[], ushort[]>(pixIndices, rawColorData.Keys.ToArray());
+            return new Tuple<byte[], ushort[]>(pixIndices, rawColorData.ToArray());
         }
 
-        private void EncodeColor(Util.Color32 col, SortedList<ushort, Util.Color32> rawColorData)
+        private void EncodeColor(Util.Color32 col, List<ushort> rawColorData, Dictionary<Util.Color32, byte> pixelColorIndexes)
         {
             switch (PaletteFormat)
             {
@@ -1094,8 +1099,10 @@ namespace SuperBMDLib.Materials
                     byte i = (byte)((col.R * 0.2126) + (col.G * 0.7152) + (col.B * 0.0722));
 
                     ushort fullIA8 = (ushort)((i << 8) | (col.A));
-                    if (!rawColorData.ContainsKey(fullIA8))
-                        rawColorData.Add((ushort)(fullIA8), col);
+                    if (!rawColorData.Contains(fullIA8))
+                        rawColorData.Add(fullIA8);
+                    if (!pixelColorIndexes.ContainsKey(col))
+                        pixelColorIndexes.Add(col, (byte)rawColorData.IndexOf(fullIA8));
                     break;
                 case PaletteFormats.RGB565:
                     ushort r_565 = (ushort)(col.R >> 3);
@@ -1107,8 +1114,10 @@ namespace SuperBMDLib.Materials
                     fullColor565 |= (ushort)(g_565 << 5);
                     fullColor565 |= (ushort)(r_565 << 11);
 
-                    if (!rawColorData.ContainsKey(fullColor565))
-                        rawColorData.Add(fullColor565, col);
+                    if (!rawColorData.Contains(fullColor565))
+                        rawColorData.Add(fullColor565);
+                    if (!pixelColorIndexes.ContainsKey(col))
+                        pixelColorIndexes.Add(col, (byte)rawColorData.IndexOf(fullColor565));
                     break;
                 case PaletteFormats.RGB5A3:
                     ushort r_53 = (ushort)(col.R >> 4);
@@ -1122,8 +1131,10 @@ namespace SuperBMDLib.Materials
                     fullColor53 |= (ushort)(r_53 << 8);
                     fullColor53 |= (ushort)(a_53 << 12);
 
-                    if (!rawColorData.ContainsKey(fullColor53))
-                        rawColorData.Add(fullColor53, col);
+                    if (!rawColorData.Contains(fullColor53))
+                        rawColorData.Add(fullColor53);
+                    if (!pixelColorIndexes.ContainsKey(col))
+                        pixelColorIndexes.Add(col, (byte)rawColorData.IndexOf(fullColor53));
                     break;
             }
         }


### PR DESCRIPTION
* Fixed PaletteFormat not being read from tex_headers.json because it had a private setter.
* Fixed PaletteCount always being written as 0. This was because PaletteCount is only decided when encoding the image, and SuperBMD was writing the header before encoding the image, at which point PaletteCount was still at the default value of 0.
* Implemented reading and writing PalettesEnabled, which is required for images that use palettes to show up correctly in game. Previously this was always written as false, which seemed to cause the game engine to use random garbage data instead of the actual palettes.

Edit:
* Fixed pixels that use certain duplicate colors having their color index being written as FF instead of the correct index.