### PR TITLE
Drag and drop functionality

### DIFF
--- a/SuperBMDLib/source/Arguments.cs
+++ b/SuperBMDLib/source/Arguments.cs
@@ -36,7 +36,7 @@ namespace SuperBMDLib
 					input_path = args[0];
                 else
                     if (i + 1 >= args.Length)
-                    throw new Exception("The parameters were malformed.")
+                    throw new Exception("The parameters were malformed.");
 
                 switch (args[i])
                 {

--- a/SuperBMDLib/source/Arguments.cs
+++ b/SuperBMDLib/source/Arguments.cs
@@ -32,6 +32,12 @@ namespace SuperBMDLib
 
             for (int i = 0; i < args.Length; i++)
             {
+				if (args[0].EndsWith(".bmd") || args[0].EndsWith(".bdl"))
+					input_path = args[0];
+                else
+                    if (i + 1 >= args.Length)
+                    throw new Exception("The parameters were malformed.")
+
                 switch (args[i])
                 {
                     case "-i":
@@ -82,8 +88,6 @@ namespace SuperBMDLib
                     case "--bdl":
                         output_bdl = true;
                         break;
-                    default:
-                        throw new Exception($"Unknown parameter \"{ args[i] }\"");
                 }
             }
 

--- a/SuperBMDLib/source/BMD/MAT3.cs
+++ b/SuperBMDLib/source/BMD/MAT3.cs
@@ -776,9 +776,9 @@ namespace SuperBMDLib.BMD
                 {
                     int texIndex = mat.TextureIndices[0];
                     //texIndex = m_TexRemapBlock[texIndex];
-                    string texPath = Path.Combine(fileDir, textures[texIndex].Name + ".png");
+                    string texFilename = textures[texIndex].Name + ".png";
 
-                    Assimp.TextureSlot tex = new Assimp.TextureSlot(texPath, Assimp.TextureType.Diffuse, 0,
+                    Assimp.TextureSlot tex = new Assimp.TextureSlot(texFilename, Assimp.TextureType.Diffuse, 0,
                         Assimp.TextureMapping.FromUV, 0, 1.0f, Assimp.TextureOperation.Add,
                         textures[texIndex].WrapS.ToAssImpWrapMode(), textures[texIndex].WrapT.ToAssImpWrapMode(), 0);
 


### PR DESCRIPTION
The application now checks if the first argument ends in ".bmd" or "bdl". If it does, it is used as the input. If it doesn't, the application will continue to switch (args[i]) to check for the traditional arguments.